### PR TITLE
Conditionally add the prefix jump

### DIFF
--- a/src/fa.py
+++ b/src/fa.py
@@ -106,7 +106,7 @@ if __name__ == '__main__':
     def process_code(c):
         n.symbols = symbols
         n.listing = []
-        n.load("\n".join(c))
+        n.load("\n".join(c), fragment=True)
 
         lst("(fragment %d)" % prg.org)
         lst("\n".join(n.listing[1:]))

--- a/src/ga144.hdr
+++ b/src/ga144.hdr
@@ -11,6 +11,8 @@ define(WIRE, `
 
 ')
 
+# LOADR must be before LOADD or you will trash your stack!!
+
 define(LOADR_8, `
     @p @p @p @p
         $1
@@ -30,6 +32,22 @@ define(LOADR_8, `
 define(LOADR_4, `LOADR_8($1, $2, $3, $4, $1, $2, $3, $4)')
 define(LOADR_2, `LOADR_4($1, $2, $1, $2)')
 
+define(LOADD_8, `
+    @p @p @p @p
+        $1
+        $2
+        $3
+        $4
+    @p @p @p @p
+        $5
+        $6
+        $7
+        $8
+    @p @p
+        $1
+        $2')
+define(LOADD_4, `LOADD_8($1, $2, $3, $4, $1, $2, $3, $4)')
+define(LOADD_2, `LOADD_4($1, $2, $1, $2)')
 dnl  NEIGHBOR(node, dir) - give node's neighbor in direction dir
 
 define(`NEIGHBOR', `dnl

--- a/src/ga144.py
+++ b/src/ga144.py
@@ -213,9 +213,10 @@ class Node():
     def isactive(self):
         return self.load_pgm is not None
 
-    def load(self, prg):
+    def load(self, prg, fragment=False):
         self.log('---------- ' + self.name + ' ----------')
         lines = [l for l in prg.split("\n") if l]
+        last_prefix_word = []
         for p in (0, 1):
             self.setpass(p)
             prefix = []     # the prefix part of the node's program
@@ -244,10 +245,15 @@ class Node():
                             print msg
                             sys.exit(1)
                         self.lst('%02x: %05x     %s' % (len(ops), opcode & 0x3ffff, ol))
+                        if prefix is target:
+                            last_prefix_word = s
                         target.append(opcode)
                 else:
                     self.lst('%02x:           %s' % (len(ops), ol))
-        self.prefix = prefix + [self.assemble("jump 0".split())]
+        if not fragment and 'jump' in last_prefix_word:
+            self.prefix = prefix
+        else:
+            self.prefix = prefix + [self.assemble("jump 0".split())]
         self.load_pgm = ops
         self.bgcolor = (0, 0, .1)
 


### PR DESCRIPTION
Instead of always appending "jump 0" to the prefix. Only add the jump when the prefix does not already end in a jump.

This did not work for fragment assembly.  I added a parameter to turn it off in that case, submitting this as a pull request because I'm not sure if it may have broken something else in one of the other projects in this repo.